### PR TITLE
update lager format string to properly get the callid into the log line

### DIFF
--- a/app.config
+++ b/app.config
@@ -8,8 +8,9 @@
                       ,{lager_file_backend, [
                                              {file, "log/console.log"}, {level, info}, {size, 10485760}, {date, "$D0"}, {count, 5}
                                             ]}
-                      ,{lager_syslog_backend, ["2600hz", local0, debug, {lager_kazoo_formatter,["|", {callid, <<"0000000000">>}, "|", module, ":", line, " (",pid, ") ", message, "\n"]}]}
+                      ,{lager_syslog_backend, ["2600hz", local0, debug, {lager_kazoo_formatter,["|", {function, <<"0000000000">>}, "|", module, ":", line, " (",pid, ") ", message, "\n"]}]}
                      ]},
           {colored, false}
+         ,{error_logger_hwm, 500}
          ]}
 ].


### PR DESCRIPTION
Should fix logging to include the call-id as before
