### PR TITLE
Fixed path in logrotate config file for Kamailio

### DIFF
--- a/system/logrotate.d/kamailio.conf
+++ b/system/logrotate.d/kamailio.conf
@@ -1,4 +1,4 @@
-/var/log/kamailio.log {
+/var/log/kamailio/kamailio.log {
     daily
     missingok
     notifempty


### PR DESCRIPTION
It should now follow this: https://github.com/2600hz/kazoo_configs/blob/master/system/rsyslog.d/10-kamailio.conf

as described here: https://github.com/2600hz/kazoo_configs/commit/7bb84dc86b46b2c2c78e4a645ef0107e04434c12
