### PR TITLE
Fixed freeswitch logrotate.d file

### DIFF
--- a/system/logrotate.d/freeswitch.conf
+++ b/system/logrotate.d/freeswitch.conf
@@ -2,12 +2,10 @@
     daily
     rotate 31
     nocreate
-    missingok
-    maxage 5
-    compress                                                                                                                                                                        
+    compress
     delaycompress
     sharedscripts
-    prerotate
-	/bin/kill -HUP `cat /usr/local/freeswitch/run/freeswitch.pid 2> /dev/null` 2> /dev/null || true
+    postrotate
+        /bin/kill -HUP `cat /var/run/freeswitch/freeswitch.pid 2> /dev/null` 2> /dev/null || true
     endscript
 }


### PR DESCRIPTION
Was not rotating properly due to:
incorrect freeswitch.pid location
prerotate instead of postrotate HUP to FS
