### PR TITLE
KAZOO-33 Retain Caller-ID during attended transfer

### DIFF
--- a/freeswitch/freeswitch.xml
+++ b/freeswitch/freeswitch.xml
@@ -38,6 +38,8 @@
 
     <X-PRE-PROCESS cmd="set" data="codecs=H263,OPUS,G7221@32000h,G7221@16000h,G722,PCMU,PCMA,G729,GSM,Speex"/>
 
+    <X-PRE-PROCESS cmd="set" data="ignore_display_updates=false"/>
+
     <section name="configuration" description="Various Configuration">
         <X-PRE-PROCESS cmd="include" data="autoload_configs/*.xml"/>
     </section>


### PR DESCRIPTION
Retain Caller-ID during attended transfer. Tests at our side confirmed that this global variable set to false makes display updates work on attended transfer and group pickup.
