### PR TITLE
OPS-1472: Update Kazoo logrotate config in kazoo-configs

### DIFF
--- a/system/logrotate.d/2600hz-platform.conf
+++ b/system/logrotate.d/2600hz-platform.conf
@@ -4,9 +4,11 @@
     notifempty
     rotate 31
     maxage 5
-    create
+    create 644
     compress
     delaycompress
+    nodateext
+    olddir 2600hz-platform-backlogs
     sharedscripts
     postrotate
         /bin/kill -HUP `cat /var/run/syslogd.pid 2> /dev/null` 2> /dev/null || true


### PR DESCRIPTION
What has been added:

- create 644: create new log file after rotation with mode 644

- nodateext: prevent adding date to old log files when rotated

- olddir 2600hz-platform-backlogs: old log files will now be stored in a separate folder '2600hz-platform-backlogs'