### PR TITLE
Printing the severity to /var/log/2600hz-platform.log helps to perform e...

### DIFF
--- a/app.config
+++ b/app.config
@@ -8,7 +8,7 @@
                       ,{lager_file_backend, [
                                              {file, "log/console.log"}, {level, info}, {size, 10485760}, {date, "$D0"}, {count, 5}
                                             ]}
-                      ,{lager_syslog_backend, ["2600hz", local0, debug, {lager_kazoo_formatter,["|", {function, <<"0000000000">>}, "|", module, ":", line, " (",pid, ") ", message, "\n"]}]}
+                      ,{lager_syslog_backend, ["2600hz", local0, debug, {lager_kazoo_formatter,["[[", severity, "]] ", "|", {function, <<"0000000000">>}, "|", module, ":", line, " (",pid, ") ", message, "\n"]}]}
                      ]},
           {colored, false}
          ,{error_logger_hwm, 500}


### PR DESCRIPTION
...vents on certain severity of logs.  Eg, when see enough logs with '[[error]]' in certain time period can notify ourselves.