### PR TITLE
Treat warnings as warnings

### DIFF
--- a/vm.args
+++ b/vm.args
@@ -15,3 +15,6 @@
 
 # Comment this line out if you want the Erlang shell
 +Bd
+
+# Treat error_logger:warning_msg/2 as warnings instead of errors (default)
++W w


### PR DESCRIPTION
Currently error_logger:warning_msg/2 are tagged as errors, which means lager prints them at the 'error' log level. This change will cause those messages to be tagged as warnings and for lager to print them at the less severe 'warning' level.