### PR TITLE
Update tls-role.cfg

### DIFF
--- a/kamailio/tls-role.cfg
+++ b/kamailio/tls-role.cfg
@@ -6,3 +6,4 @@ listen=TLS_ALG_SIP
 ####### TLS Parameters #########
 loadmodule "tls.so"
 modparam("tls", "config", "/etc/kazoo/kamailio/tls.cfg")
+modparam("tls", "low_mem_threshold1", 0)


### PR DESCRIPTION
Added low_mem_threshold1 setting to 0.  TLS connections will not fail preemptively.