### PR TITLE
HELP-21051 reselect when associated media is unavailable

### DIFF
--- a/kamailio/dispatcher-role.cfg
+++ b/kamailio/dispatcher-role.cfg
@@ -104,7 +104,8 @@ route[DISPATCHER_FIND_ROUTES]
         $var(prefered_route) = $sht(associations=>$var(contact_uri));
         xlog("L_INFO", "$ci|log|found association for contact uri $var(contact_uri)");
         if (!route(DISPATCHER_REORDER_ROUTES)) {
-            $sht(associations=>$var(association)) = $null;
+            $sht(associations=>$var(contact_uri)) = $null;
+            route(DISPATCHER_FIND_ROUTES);
         }
     }
 }


### PR DESCRIPTION
if the associated media is unavailable, clear the association and reselect