### PR TITLE
HELP-22078 query cluster for call-id when relevant

### DIFF
--- a/kamailio/fast-pickup-role.cfg
+++ b/kamailio/fast-pickup-role.cfg
@@ -31,11 +31,14 @@ route[FAST_PICKUP_ATTEMPT]
        $var(replaced_call_id) = $(hdr(Replaces){s.select,0,;});
     }
 
-    if($var(replaced_call_id) != "none") {
-       xlog("L_INFO", "$ci|log|replaces call-id $var(replaced_call_id)");
+### when the cluster has the ability to respond to parked call-id (fake call)
+### remove the 2nd question '&& !($(ru{uri.user}) =~ "\*3")'
+    if($var(replaced_call_id) != "none" && !($(ru{uri.user}) =~ "\*3")) {
+       xlog("L_INFO", "$ci|log|querying cluster for location of call-id $var(replaced_call_id)");
        $var(amqp_payload_request) = '{"Event-Category" : "call_event" , "Event-Name" : "channel_status_req", "Call-ID" : "' + $var(replaced_call_id) + '", "Active-Only" : true }';
        $var(amqp_routing_key) = "call.status_req." + $(var(replaced_call_id){kz.encode});
-       sl_send_reply("100", "Attempting K query");
+       sl_send_reply("100", "Attempting to connect your call");
+       $avp(kz_timeout) = 500;
        if(kazoo_query("callevt", $var(amqp_routing_key), $var(amqp_payload_request))) {
            $du = $(kzR{kz.json,Switch-URL});
            if($du != $null) {


### PR DESCRIPTION
this minimizes the impact of UAs that do not respect the dialog-info sent for fast pickup