### PR TITLE
fix antiflood reset auth

### DIFF
--- a/kamailio/antiflood-role.cfg
+++ b/kamailio/antiflood-role.cfg
@@ -54,7 +54,7 @@ route[ANTIFLOOD_SUCCESSFUL_AUTH]
 
 route[ANTIFLOOD_RESET_AUTH]
 {
-    $var(user) = "sip:" + $(kzE{kz.json,Username}) + "@" + $(kzE{kz.json,Realm});
+    $var(user) = $(kzE{kz.json,Username}) + "@" + $(kzE{kz.json,Realm});
     sht_rm_name_re("antiflood=>$(var(user){re.subst,/\\./\\\\./g})::.*");
 }
 


### PR DESCRIPTION
removed the "sip:" prefix