### PR TITLE
KAZOO-4863 As Admin need logging for slow Kamilio script commands and…

### DIFF
--- a/kamailio/default.cfg
+++ b/kamailio/default.cfg
@@ -30,6 +30,8 @@ mem_summary = 12
 log_stderror = no
 log_facility = LOG_LOCAL0
 log_name="kamailio"
+latency_limit_action=2000
+latency_limit_db=2000
 
 ####### Alias Parameters #########
 auto_aliases = yes
@@ -579,6 +581,7 @@ route[INTERNAL_TO_EXTERNAL_RELAY]
     remove_hf_re("^X-.*");
 
     t_on_reply("EXTERNAL_REPLY");
+    t_on_failure("EXTERNAL_FAULT");
 
     t_set_fr(0, 10000);
 
@@ -618,6 +621,8 @@ route[EXTERNAL_TO_INTERNAL_RELAY]
 
 onreply_route[EXTERNAL_REPLY]
 {
+    # this route handles replies that are coming from a carrier or customer device
+    xlog("L_INFO", "$ci|start|received external $rm reply $T_reply_code $rr source $si:$sp");
     xlog("L_INFO", "$ci|log|external reply $T_reply_code");
 
     #!ifdef WEBSOCKETS-ROLE
@@ -641,9 +646,10 @@ onreply_route[EXTERNAL_REPLY]
 
 onreply_route[INTERNAL_REPLY]
 {
-    # this route handles replies that are comming from our media server
+    # this route handles replies that are coming from our media server
     xlog("L_INFO", "$ci|start|received internal reply $T_reply_code $rr");
     xlog("L_INFO", "$ci|log|source $si:$sp");
+    xlog("L_INFO", "$ci|log|method $rm");
 
     #!ifdef WEBSOCKETS-ROLE
     route(NAT_WEBSOCKETS_CORRECT);
@@ -684,6 +690,20 @@ onreply_route[INTERNAL_REPLY]
     $var(reply_reason) = $rr;
 }
 
+failure_route[EXTERNAL_FAULT]
+{
+    if($T(reply_type)==1){
+        # a request timeout, destination did not respond in time, does not show up in on_reply
+        # http://www.kamailio.org/wiki/cookbooks/4.3.x/pseudovariables#t_name
+        if(isflagset(FLAG_SESSION_PROGRESS) {
+            #may be during re-invite, update, bye, cancel, etc or initial invite after 18x (transaction has a to tag)
+            xlog("L_INFO", "$ci|start|external failure route, $T_reply_code locally generated for method $rm after progress");
+        } else {
+            xlog("L_INFO", "$ci|start|external failure route, $T_reply_code locally generated for method $rm no progress");
+        }
+    }
+}
+
 failure_route[INTERNAL_FAULT]
 {
     # this branch handles failures (>=300) to our media servers,
@@ -691,6 +711,16 @@ failure_route[INTERNAL_FAULT]
 
     # if the failure cause was due to the transaction being
     # cancelled then we are complete
+    if($T(reply_type)==1){
+        # a request timeout, destination did not respond in time, does not show up in on_reply
+        # http://www.kamailio.org/wiki/cookbooks/4.3.x/pseudovariables#t_name
+        if(isflagset(FLAG_SESSION_PROGRESS) {
+            #may be during re-invite, update, bye, cancel, etc or initial invite after 18x (transaction has a to tag)
+            xlog("L_INFO", "$ci|start|internal failure route, $T_reply_code locally generated for method $rm after progress");
+        } else {
+            xlog("L_INFO", "$ci|start|internal failure route, $T_reply_code locally generated for method $rm no progress");
+        }
+    }
     if (t_is_canceled()) {
         xlog("L_INFO", "$ci|log|transaction was cancelled");
         exit;


### PR DESCRIPTION
… enhanced failure logs

Per support ticket 20982 and suggestions from kamailio author Daniel related to that ticket... 
Adding settings that log config script commands take "too long". 
Starting with setting the too long at 2 seconds. 

Also adding logging that will show messages that are generated by kamailio like 408 timeout. Also show the method, response code and reason in the failure route logs. Normally most of that is shown in on reply but with generated messages there is no on-reply route.