### PR TITLE
KAZOO-4895 Fixed config file syntax error and renamed route function

### DIFF
--- a/kamailio/default.cfg
+++ b/kamailio/default.cfg
@@ -271,7 +271,7 @@ route
     #!endif
 
     #!ifdef TRAFFIC_FILTER-ROLE
-    route(TRAFFIC_FILTER);
+    route(FILTER_REQUEST);
     #!endif
 
     #!ifdef ACL-ROLE

--- a/kamailio/traffic-filter-role.cfg
+++ b/kamailio/traffic-filter-role.cfg
@@ -1,4 +1,4 @@
-route[TRAFFIC_FILTER]
+route[FILTER_REQUEST]
 {
     # allow request from internal network or from whitelist
     if (isflagset(FLAG_TRUSTED_SOURCE)) {
@@ -6,13 +6,13 @@ route[TRAFFIC_FILTER]
     }
 
     #  drop requests with no To domain or IP To domain (friendly-scanner)
-    if (is_method("REGISTER|SUBSCRIBE") {
+    if (is_method("REGISTER|SUBSCRIBE")) {
         route(FILTER_TO_DOMAIN);
         route(FILTER_FROM_DOMAIN);
     }
 
     # drop Invite with IP auth realm
-    if (is_method("INVITE") {
+    if (is_method("INVITE")) {
         route(FILTER_REQUEST_DOMAIN);
         route(FILTER_AUTHORIZATION_DOMAIN);
     }


### PR DESCRIPTION
KAZOO-4895 Fixed config file syntax error and renamed route[TRAFFIC_FILTER]