### PR TITLE
added the default debian path for kamailio modules to kamailio's defa…

### DIFF
--- a/kamailio/default.cfg
+++ b/kamailio/default.cfg
@@ -81,7 +81,7 @@ dns_srv_lb = off
 disable_sctp = yes
 
 ####### Modules Section ########
-mpath="/usr/lib64/kamailio/modules/"
+mpath="/usr/lib64/kamailio/modules/:/usr/lib/x86_64-linux-gnu/kamailio/modules/"
 
 ######## Kamailio stun module ########
 loadmodule "stun.so"


### PR DESCRIPTION
When installing kamailio under debian jessie from the official repo's I discovered the module path for kamailio was different and required this small addition to work.  

I think this is preferable to requiring everyone to remember to implement a symlink.