### PR TITLE
Fixing kamailio logging when started from kazoo-kamailio

### DIFF
--- a/system/sbin/kazoo-kamailio
+++ b/system/sbin/kazoo-kamailio
@@ -121,7 +121,7 @@ case "$1" in
 		;;
 	start)
 		shift
-		start -DD -E $@
+		start -DD $@
 		;;
 	stop)
 		stop


### PR DESCRIPTION
Removing flag from start in kazoo-kamailio that was causing logging to stderr only