### PR TITLE
Kamailio config fixes

### DIFF
--- a/kamailio/default.cfg
+++ b/kamailio/default.cfg
@@ -167,10 +167,10 @@ loadmodule "kazoo.so"
 modparam("kazoo", "node_hostname",  "MY_HOSTNAME")
 modparam("kazoo", "amqp_connection", "MY_AMQP_URL")
 #!ifdef MY_AMQP_URL_SECONDARY
-modparam("kazoo", "amqp_connection", "MY_AMQP_URL_SECONDARY")
+modparam("kazoo", "amqp_connection", "MY_SECONDARY_AMQP_URL")
 #!endif
 #!ifdef MY_AMQP_URL_TERTIARY
-modparam("kazoo", "amqp_connection", "MY_AMQP_URL_TERTIARY")
+modparam("kazoo", "amqp_connection", "MY_TERTIARY_AMQP_URL")
 #!endif
 #!ifdef MY_AMQP_MAX_CHANNELS
 modparam("kazoo", "amqp_max_channels", MY_AMQP_MAX_CHANNELS)

--- a/kamailio/local.cfg
+++ b/kamailio/local.cfg
@@ -46,6 +46,11 @@ debug = L_INFO
 ##     in the zone that this server will service.
 #!substdef "!MY_AMQP_URL!kazoo://guest:guest@127.0.0.1:5672!g"
 
+## Disabled amqp servers - remove all but the last '#' to enable secondary
+##   and tertiary amqp servers
+# # #!substdef "!MY_SECONDARY_AMQP_URL!kazoo://guest:guest@127.0.0.1:5672!g"
+# # #!substdef "!MY_SECONDARY_AMQP_URL!kazoo://guest:guest@127.0.0.1:5672!g"
+
 ## This parameter is only required if you are using websockets
 ##     This value must be present in the HTTP 
 ##     Origin header on a new websocket request

--- a/kamailio/presence_notify_sync-role.cfg
+++ b/kamailio/presence_notify_sync-role.cfg
@@ -20,7 +20,7 @@ onreply_route[PRESENCE_NOTIFY_REPLY]
     xlog("L_INFO", "$ci|log|sent notify callback for event $avp(notify_event) : $tu\n");
 }
 
-onreply_route[PRESENCE_NOTIFY_FAULT]
+failure_route[PRESENCE_NOTIFY_FAULT]
 {
     $var(amqp_payload_request) = '{"Event-Category" : "presence", "Event-Name" : "notify", "Event-Package" : "$avp(notify_event)", "Call-ID" : "$ci", "From" : "$fu", "To" : "$tu", "Body" : "$(avp(notify_body){s.escape.common})", "Sequence" : $cs, "Reply" : $T_reply_code }';
     $var(rk) = "notify." + $(td{kz.encode}) + "." + $(tU{kz.encode});


### PR DESCRIPTION
Part 1: Fixes for a substring collision bug in kamailio config
Part 2: Fix for improper routing to an `onreply_route` using `t_on_failure()`

Full details in the commit comments
