### PR TITLE
Added registrar port support to Proxy-Path

### DIFF
--- a/kamailio/registrar-role.cfg
+++ b/kamailio/registrar-role.cfg
@@ -281,11 +281,12 @@ route[SAVE_LOCATION]
     }
 
     $var(ip) = $Ri;
+    $var(port) = $Rp;
     if(af==INET6) {
        $var(ip) = "[" + $Ri + "]";
     }
 
-    $var(amqp_payload_request) = '{"Event-Category" : "directory", "Event-Name" : "reg_success", "Status" : "$var(Status)", "Event-Timestamp" : $TS, "Expires" : $(var(expires){s.int}), "First-Registration" : $var(new_reg), "Contact" : "$(ct{s.escape.common})", "Call-ID" : "$ci", "Realm" : "$fd", "Username" : "$fU", "From-User" : "$fU", "From-Host" : "$fd", "To-User" : "$tU", "To-Host" : "$td", "User-Agent" : "$(ua{s.escape.common})" , "Custom-Channel-Vars" : $xavp(ulattrs=>custom_channel_vars), "Proxy-Path" : "sip:$var(ip)", "RUID" : "$xavp(ulrcd=>ruid)" }';
+    $var(amqp_payload_request) = '{"Event-Category" : "directory", "Event-Name" : "reg_success", "Status" : "$var(Status)", "Event-Timestamp" : $TS, "Expires" : $(var(expires){s.int}), "First-Registration" : $var(new_reg), "Contact" : "$(ct{s.escape.common})", "Call-ID" : "$ci", "Realm" : "$fd", "Username" : "$fU", "From-User" : "$fU", "From-Host" : "$fd", "To-User" : "$tU", "To-Host" : "$td", "User-Agent" : "$(ua{s.escape.common})" , "Custom-Channel-Vars" : $xavp(ulattrs=>custom_channel_vars), "Proxy-Path" : "sip:$var(ip):$var(port)", "RUID" : "$xavp(ulrcd=>ruid)" }';
     $var(amqp_routing_key) = "registration.success." + $(fd{kz.encode}) + "." + $(fU{kz.encode});
     kazoo_publish("registrar", $var(amqp_routing_key), $var(amqp_payload_request));
 


### PR DESCRIPTION
When phones register to kamailio and subsequently advertise to ecallmgr their registrar information, the port in which the endpoint registered against was not being sent to ecallmgr.  This adds that to the amqp publish request so calls can correctly route back to the appropriate port when the device is called.
