### PR TITLE
Fixed pidfile location

### DIFF
--- a/system/sbin/kazoo-freeswitch
+++ b/system/sbin/kazoo-freeswitch
@@ -11,12 +11,12 @@ fi
 RETVAL=1
 USER=${FS_USER:-freeswitch}
 BIN_FILE=${FS_BIN:-/usr/bin/freeswitch}
-PID_FILE=${FS_PID:-/var/run/freeswitch/kazoo-freeswitch.pid}
+PID_FILE=${FS_PID:-/var/run/freeswitch/freeswitch.pid}
 CFG_FILE=${FS_CONFIG:-/etc/kazoo/freeswitch}
 export HOME=${FS_HOME:-/var/lib/kazoo-freeswitch}
 
 if [ -z "${FREESWITCH_ARGS}" ]; then
-	FREESWITCH_ARGS="-nonat -conf ${CFG_FILE} -db /var/lib/kazoo-freeswitch/db -log /var/log/freeswitch -cache /var/lib/kazoo-freeswitch/cache -sounds /usr/share/kazoo-freeswitch/sounds -storage /var/lib/kazoo-freeswitch/storage"
+	FREESWITCH_ARGS="-nonat -conf ${CFG_FILE} -run /var/run/freeswitch -db /var/lib/kazoo-freeswitch/db -log /var/log/freeswitch -cache /var/lib/kazoo-freeswitch/cache -sounds /usr/share/kazoo-freeswitch/sounds -storage /var/lib/kazoo-freeswitch/storage"
 fi
 
 prepare() {

--- a/system/systemd/kazoo-freeswitch.service
+++ b/system/systemd/kazoo-freeswitch.service
@@ -16,6 +16,7 @@ ExecStartPre=/usr/sbin/kazoo-freeswitch prepare
 ExecStart=/usr/sbin/kazoo-freeswitch start -nc -nf
 ExecReload=/usr/bin/kill -HUP $MAINPID
 Restart=on-abort
+PIDFile=/var/run/freeswitch/freeswitch.pid
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
First change: Systemd supports a PIDFile value in the service file that will automatically remove the pidfile when the service stops. 

Second change:  The /usr/bin/freeswitch binary permits an argument to specify the run directory, If no -run is specified, it writes the pidfile to /var/log/freeswitch which is not correct. Freeswitch does not seem to permit setting the pidfile name to an arbitrary name which is why the name was changed for the value of the PID_FILE variable. I left the prepare line in that removes the pid file just to be safe, but it should not be needed with the addition of the systemd PIDFile setting.  
