### PR TITLE
Added timers for freeswitch logrotate via systemd

### DIFF
--- a/system/systemd/kazoo-freeswitch-logrotate.service
+++ b/system/systemd/kazoo-freeswitch-logrotate.service
@@ -1,0 +1,6 @@
+[Unit]
+Description=Run logrotate for freeswitch
+
+[Service]
+Type=oneshot
+ExecStart=/usr/sbin/logrotate --force /etc/logrotate.d/freeswitch.conf

--- a/system/systemd/kazoo-freeswitch-logrotate.timer
+++ b/system/systemd/kazoo-freeswitch-logrotate.timer
@@ -1,0 +1,9 @@
+[Unit]
+Description=Rotate the kazoo-freeswitch logs every 15 minutes
+
+[Timer]
+OnCalendar=*:0/15
+Unit=kazoo-freeswitch-logrotate.service
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
Systemd timers are way easier to manage via installation scripts than cron jobs so let's do that! To enable them you need to run `systemctl enable kazoo-freeswitch-logrotate.timer` and `systemctl start kazoo-freeswitch-logrotate.timer`. This is currently setup to rotate the fs log files every 15 minutes and depends on the logrotate files which are already present in kazoo configs. 

To list the timers just run `systemctl list-timers`
