### PR TITLE
fix systemd

### DIFF
--- a/system/systemd/kazoo-freeswitch.service
+++ b/system/systemd/kazoo-freeswitch.service
@@ -1,7 +1,6 @@
 [Unit]
 Description=FreeSWITCH Configured for Kazoo
-After=syslog.target network.target
-After=postgresql.service postgresql-9.3.service postgresql-9.4.service mysqld.service httpd.service
+After=syslog.target network-online.target
 
 [Service]
 User=freeswitch


### PR DESCRIPTION
I do not think CentOS v7 supports multiple "After" lines.  The second line is not really relevant to Kazoo anyways.  

Without network-online.target, Freeswitch does not start correctly.  The symptom was that Kamailio does not see Freeswitch after reboot until Freeswitch is restarted.