### PR TITLE
Update registrar-role.cfg

### DIFF
--- a/kamailio/registrar-role.cfg
+++ b/kamailio/registrar-role.cfg
@@ -99,7 +99,7 @@ route[AUTHORIZATION_CHECK]
     $xavp(regcfg=>match_received) = $su;
     if(!(registered("location", "$fu", 2, 1) == 1 && $(xavp(ulattrs=>custom_channel_vars){s.len}) > 1)) {
         xlog("L_INFO", "$ci|log|not authorized $fu from $si:$sp\n");
-        send_reply("500", "Not Registered");
+        send_reply("503", "Not Registered");
         exit;
 #       route(ATTEMPT_AUTHORIZATION);
     }
@@ -152,7 +152,7 @@ route[KAZOO_AUTHORIZATION]
     if(kazoo_async_query("callmgr", $var(amqp_routing_key), $var(amqp_payload_request), "KAZOO_AUTHORIZATION_OK", "KAZOO_AUTHORIZATION_ERROR") != 1) {
         xlog("L_INFO", "$ci|log|failed to send Kazoo query for authentication credentials for $Au $si:$sp\n");
         append_to_reply("Retry-After: 60\r\n");
-        send_reply("500", "Retry Later");
+        send_reply("503", "Retry Later");
         exit;
     }
 }
@@ -177,7 +177,7 @@ route[KAZOO_AUTHORIZATION_ERROR]
 {
     xlog("L_INFO", "$ci|log|failed to query Kazoo for authentication credentials for $Au $si:$sp\n");
     append_to_reply("Retry-After: 60\r\n");
-    send_reply("500", "Retry Later");
+    send_reply("503", "Retry Later");
     exit;
 }
 


### PR DESCRIPTION
Customer has discovered that 3CX devices (and some others) actually interpret a "500" as a "go away forever" message, but a 503 is a "retry later". Soooo gonna change this so that more devices are happier.