### PR TITLE
Stop URL encoding INVITEs due to # (+ others)

### DIFF
--- a/freeswitch/freeswitch.xml
+++ b/freeswitch/freeswitch.xml
@@ -34,6 +34,7 @@
     <X-PRE-PROCESS cmd="set" data="recordings_dir=/tmp/"/>
     <X-PRE-PROCESS cmd="set" data="send_silence_when_idle=400"/>
     <X-PRE-PROCESS cmd="set" data="sdp_m_per_ptime=false"/>
+    <X-PRE-PROCESS cmd="set" data="sofia_suppress_url_encoding=true"/>
     <X-PRE-PROCESS cmd="set" data="codecs=OPUS,VP8,H263,H264,G7221@32000h,G7221@16000h,G722,PCMU,PCMA,G729,GSM,Speex"/>
     
     <section name="configuration" description="Various Configuration">


### PR DESCRIPTION
While the FreeSWITCH team might be correct that # and other symbols are considered required to URL encode for sanity, this seems to break popular providers like Flowroute. So, we're not going to do this.