### PR TITLE
Remove debug log line from default.cfg

### DIFF
--- a/kamailio/default.cfg
+++ b/kamailio/default.cfg
@@ -25,7 +25,6 @@ pv_buffer_size=65536
 mem_join=1
 
 ####### Logging Parameters #########
-debug = L_INFO
 memdbg = 10
 memlog = L_INFO
 corelog = L_ERR


### PR DESCRIPTION
Remove debug log line 
debug = L_INFO

This is duplicated in local.cfg and means that even if the user changes the log level in local.cfg it is overwritten by default.cfg