### PR TITLE
Update local.cfg

### DIFF
--- a/kamailio/local.cfg
+++ b/kamailio/local.cfg
@@ -23,6 +23,8 @@
 # # #!trydef REGISTRAR_SYNC_ROLE
 # # #!trydef PRESENCE_SYNC_ROLE
 # # #!trydef PRESENCE_NOTIFY_SYNC_ROLE
+# # #!ifdef MY_AMQP_SECONDARY_URL
+# # #!ifdef MY_AMQP_TERTIARY_URL
 
 ################################################################################
 ## SERVER INFORMATION


### PR DESCRIPTION
Add secondary and tertiary amqp as defined in default.cfg.

Also, I think there is a typo on your kamailio docs at http://www.kamailio.org/docs/modules/4.4.x/modules/kazoo.html

4.1.6. amqp_connection(str)

The connection url to rabbitmq. can be set multiple times for failover.

Example 1.7. Set amqp_connection parameter

...
modparam("kazoo", "amqp_connection", "amqp://guest:guest@localhost:5672")
modparam("kazoo", "amqp_connection", "kazoo://guest:guest@otherhost:5672")
...

Shouldn't the second modparam say:
"amqp://guest:guest@otherhost:5672" 