### PR TITLE
remove ipops module from acl-role

### DIFF
--- a/kamailio/acl-role.cfg
+++ b/kamailio/acl-role.cfg
@@ -2,7 +2,6 @@
 # Default "order" is "deny,allow".
 # So if there is no data from DB request will be permitted by default.
 #
-loadmodule "ipops.so"
 modparam("htable", "htable", "acl=>initval=-1;autoexpire=7200")
 
 #!trydef ACL_MESSAGE_DENY "Rejected by ACL"


### PR DESCRIPTION
Since Kamailio ipops module was added to default config it probably not needed here anymore...