### PR TITLE
Update kazoo-kamailio

### DIFF
--- a/system/sbin/kazoo-kamailio
+++ b/system/sbin/kazoo-kamailio
@@ -84,7 +84,7 @@ reset-restart() {
 }
 
 status() {
-	kamctl fifo ds_list
+	kamcmd dispatcher.list
 	RETVAL=$?
 }
 


### PR DESCRIPTION
mi_fifo has been removed from Kamailio v5.  So ```kazoo-kamailio status``` will no longer work without this change.