### PR TITLE
Remove duplicate loadmodule sqlops

### DIFF
--- a/kamailio/registrar-sync-role.cfg
+++ b/kamailio/registrar-sync-role.cfg
@@ -1,12 +1,5 @@
 ######## Presence sync server module ########
 
-####### SQL OPS module ##########
-#!ifndef SQLOPS_LOADED
-loadmodule "sqlops.so"
-modparam("sqlops","sqlcon", "cb=>KAZOO_DB_URL")
-#!trydef SQLOPS_LOADED
-#!endif
-
 event_route[kazoo:consumer-event-directory-reg-sync]
 {
     $var(Server) = $(kzE{kz.json,Server-ID});


### PR DESCRIPTION
Fix registrar-sync-role.cfg after PR #163 

Error before change:
```
May 12 21:38:13 aio.kazoo.com kamailio[24189]: CRITICAL: <core> [core/cfg.y:3401]: yyerror_at(): parse error in config file /etc/kamailio/registrar-sync-role.cfg, line 5, column 12-22: failed to load module
May 12 21:38:13 aio.kazoo.com kamailio[24189]: ERROR: sqlops [sql_api.c:78]: sql_init_con(): duplicate connection name
May 12 21:38:13 aio.kazoo.com kamailio[24189]: CRITICAL: <core> [core/cfg.y:3404]: yyerror_at(): parse error in config file /etc/kamailio/registrar-sync-role.cfg, line 6, column 47: Can't set module parameter
```